### PR TITLE
[Proposal] - Import maps

### DIFF
--- a/mock-server/api/v1/microlc/configuration/importMap/get.js
+++ b/mock-server/api/v1/microlc/configuration/importMap/get.js
@@ -1,0 +1,11 @@
+const importMap = {
+  "imports": {
+    "lodash": "https://unpkg.com/lodash@4.17.21/lodash.js"
+  }
+}
+
+module.exports = (request, response) => {
+  response
+    .delay(1000)
+    .send(importMap)
+}

--- a/mock-server/api/v1/microlc/configuration/lodash-test/get.js
+++ b/mock-server/api/v1/microlc/configuration/lodash-test/get.js
@@ -1,0 +1,3 @@
+module.exports = (req, res) => {
+  res.type('application/javascript').sendFile('lodash-test.js', {root: './mock-server/api/v1/microlc/configuration/lodash-test'})
+}

--- a/mock-server/api/v1/microlc/configuration/lodash-test/lodash-test.js
+++ b/mock-server/api/v1/microlc/configuration/lodash-test/lodash-test.js
@@ -1,0 +1,3 @@
+import "lodash";
+const result = _.dropRight([1, 2, 3]);
+console.log(`Lodash result ${result}`)

--- a/mock-server/api/v1/microlc/configuration/{configFile}/get.js
+++ b/mock-server/api/v1/microlc/configuration/{configFile}/get.js
@@ -8,6 +8,14 @@ const configuration = {
       "type": "element",
       "tag": "script",
       "attributes": {
+        "src": "./api/v1/microlc/configuration/lodash-test",
+        "type": "module"
+      }
+    },
+    {
+      "type": "element",
+      "tag": "script",
+      "attributes": {
         "data-stencil-namespace": "duet"
       }
     },

--- a/packages/fe-container/src/components/ElementsContainer.tsx
+++ b/packages/fe-container/src/components/ElementsContainer.tsx
@@ -22,7 +22,7 @@ const propTypes = {
 type ElementsContainerProps = PropTypes.InferProps<typeof propTypes>
 
 const ElementsContainer: React.FC<ElementsContainerProps> = (props: any = {}) => {
-  const {configurationName = 'microlc-element-composer', currentUser, headers, container, importMap = 'importMap'} = props
+  const {configurationName = 'microlc-element-composer', currentUser, headers, container, importMap} = props
 
   return (
     <>

--- a/packages/fe-container/src/components/ElementsContainer.tsx
+++ b/packages/fe-container/src/components/ElementsContainer.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Composer from './Composer'
+import ImportMap from './ImportMap'
+
+const currentUserShape = PropTypes.shape({
+  avatar: PropTypes.string,
+  email: PropTypes.string.isRequired,
+  groups: PropTypes.arrayOf(PropTypes.string.isRequired),
+  name: PropTypes.string.isRequired,
+  nickname: PropTypes.string
+})
+
+const propTypes = {
+  configurationName: PropTypes.string,
+  importMap: PropTypes.string,
+  currentUser: currentUserShape,
+  headers: PropTypes.object,
+  container: PropTypes.object
+}
+
+type ElementsContainerProps = PropTypes.InferProps<typeof propTypes>
+
+const ElementsContainer: React.FC<ElementsContainerProps> = (props: any = {}) => {
+  const {configurationName = 'microlc-element-composer', currentUser, headers, container, importMap = 'importMap'} = props
+
+  return (
+    <>
+      <ImportMap container={container} importMap={importMap} />
+      <Composer
+        configurationName={configurationName}
+        currentUser={currentUser}
+        headers={headers}
+      />
+    </>
+  )
+}
+
+export default ElementsContainer

--- a/packages/fe-container/src/components/ImportMap.tsx
+++ b/packages/fe-container/src/components/ImportMap.tsx
@@ -1,0 +1,49 @@
+import React, {useEffect} from 'react'
+import PropTypes from 'prop-types'
+
+import useConfiguration from '../hooks/useConfiguration'
+import createNode from '../composer/NodeCreator'
+import {ReplaySubject} from 'rxjs'
+
+const createImportShim = () => {
+  return createNode({
+    type: 'element',
+    tag: 'script',
+    attributes: {
+      src: 'https://ga.jspm.io/npm:es-module-shims@1.4.3/dist/es-module-shims.js'
+    }
+  }, {}, {}, new ReplaySubject<any>())
+}
+
+const createImportMap = (importMapContent: any): HTMLElement => {
+  return createNode({
+    type: 'element',
+    tag: 'script',
+    attributes: {
+      type: 'importmap'
+    },
+    properties: {
+      innerText: JSON.stringify(importMapContent)
+    }
+  }, {}, {}, new ReplaySubject<any>())
+}
+
+const ImportMap: React.FC<any> = ({importMap, container}) => {
+  const configuration = useConfiguration(importMap)
+
+  useEffect(() => {
+    if (configuration) {
+      container.appendChild(createImportMap(configuration))
+      container.appendChild(createImportShim())
+    }
+  }, [configuration, container])
+
+  return <></>
+}
+
+ImportMap.propTypes = {
+  container: PropTypes.object,
+  importMap: PropTypes.string
+}
+
+export default ImportMap

--- a/packages/fe-container/src/hooks/useConfiguration.ts
+++ b/packages/fe-container/src/hooks/useConfiguration.ts
@@ -5,9 +5,10 @@ const useConfiguration = (configurationName: string) => {
   const [configuration, setConfiguration] = useState<Configuration>()
 
   useEffect(() => {
-    fetch(`./api/v1/microlc/configuration/${configurationName}`)
-      .then(response => response.json())
-      .then(setConfiguration)
+    configurationName &&
+      fetch(`./api/v1/microlc/configuration/${configurationName}`)
+        .then(response => response.json())
+        .then(setConfiguration)
   }, [configurationName])
 
   return configuration

--- a/packages/fe-container/src/index.tsx
+++ b/packages/fe-container/src/index.tsx
@@ -18,7 +18,7 @@ import './public-path'
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import Composer from './components/Composer'
+import ElementsContainer from './components/ElementsContainer'
 
 const CONTAINER_ID = '#microlc-element-composer'
 
@@ -27,13 +27,9 @@ function retrieveContainer (props: any) {
   return container ? container.querySelector(CONTAINER_ID) : document.querySelector(CONTAINER_ID)
 }
 
-function render (props: any) {
+function render (props: any = {}) {
   ReactDOM.render(
-    <Composer
-      configurationName={props.configurationName}
-      currentUser={props.currentUser}
-      headers={props.headers}
-    />,
+    <ElementsContainer {...props} container={retrieveContainer(props)} />,
     retrieveContainer(props)
   )
 }
@@ -52,6 +48,5 @@ export async function bootstrap () {
 
 // @ts-ignore
 if (!window.__POWERED_BY_QIANKUN__) {
-  const configurationName = 'microlc-element-composer'
-  render({configurationName})
+  render()
 }


### PR DESCRIPTION
Hi everyone,
here is a proposal to support import maps inside the element composer.

Import maps is officially a way `to control the behavior of JavaScript imports`: even if it's still a draft since 2018, Chrome 89+ is [supporting it OOB](https://caniuse.com/?search=import%20maps).

To introduce the support for the other browsers, we use the [es-module-shim polyfill](https://github.com/guybedford/es-module-shims).

Import maps allows us to create lightweight bundles, externalizing their dependencies (i.e. `react`, `lodash`...) as `peer-dependencies`. These `peer-dependencies` are declared as `importmap` and will be imported at run-time only when needed, using a CDN or a static file that you can expose wherever you want.

A complete description of the importmap draft can be found [here](https://github.com/WICG/import-maps).

This is still a proposal because I don't know yet if it's better to support import maps directly in micro-lc.

Let me know your thoughts.